### PR TITLE
AUT-13547 | Endless Loading Because Of Vehicle Color | added hook to …

### DIFF
--- a/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
+++ b/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
@@ -40,7 +40,8 @@ const AvailabilityVehicle = ({
   location,
   id,
 }: AvailabilityVehicleProps) => {
-  const { vehicleColor } = useContext(ThemeContext);
+  const { useVehicleColor } = useContext(ThemeContext);
+  const { vehicleColor } = useVehicleColor();
   const markerRef = useRef<MarkerAnimated>(null);
   const [locationAnimated] = useState(new AnimatedRegion({
     latitude: insureNumberType(location.lat),

--- a/examples/client/Locomotion/src/context/theme/index.js
+++ b/examples/client/Locomotion/src/context/theme/index.js
@@ -125,13 +125,34 @@ export const FONT_WEIGHTS = {
 //   SMALL_LIGHT: FONT_WEIGHT.LIGHT.concat(FONT_SIZES.SMALL),
 // }
 
+/**
+ * useVehicleColor hook
+ * once called, get the vehicle color setting and update its vehicleColor, asyncly
+ * return the vehicleColor
+ */
+const useVehicleColor = () => {
+  const { getSettingByKey } = settings.useContainer();
+  const [vehicleColor, setVehicleColor] = useState(null);
+
+  const getVehicleColor = async () => {
+    const color = await getSettingByKey(
+      SETTINGS_KEYS.VEHICLE_COLOR,
+    );
+    setVehicleColor(color);
+  };
+
+  useEffect(() => {
+    getVehicleColor();
+  }, []);
+
+  return { vehicleColor };
+};
+
 
 const Provider = ({ children }) => {
   const colorScheme = useColorScheme();
-  const { getSettingByKey } = settings.useContainer();
   const isInitDarkMode = FORCE_DARK_MODE || (Appearance.getColorScheme() === THEME_MOD.DARK && DARK_MODE_ENABLED);
   const [isDarkMode, setDarkMode] = useState(isInitDarkMode);
-  const [vehicleColor, setVehicleColor] = useState(null);
   // Appearance.addChangeListener()
   useEffect(() => {
     if (!FORCE_DARK_MODE && DARK_MODE_ENABLED) {
@@ -139,22 +160,12 @@ const Provider = ({ children }) => {
     }
   }, [colorScheme]);
 
-  const checkVehicleColor = async () => {
-    const color = await getSettingByKey(
-      SETTINGS_KEYS.VEHICLE_COLOR,
-    );
-    setVehicleColor(color);
-  };
-  useEffect(() => {
-    checkVehicleColor();
-  }, []);
-
   return (
     <ThemeProvider
       theme={{
         isDarkMode,
         ...(isDarkMode ? darkTheme : lightTheme),
-        vehicleColor,
+        useVehicleColor,
       }}
     >
       {children}

--- a/examples/client/Locomotion/src/context/theme/index.js
+++ b/examples/client/Locomotion/src/context/theme/index.js
@@ -127,8 +127,8 @@ export const FONT_WEIGHTS = {
 
 /**
  * useVehicleColor hook
- * once called, get the vehicle color setting and update its vehicleColor, asyncly
- * return the vehicleColor
+ * Once called, it'll get the vehicle color setting and update vehicleColor, asynchronously
+ * @return vehicleColor
  */
 const useVehicleColor = () => {
   const { getSettingByKey } = settings.useContainer();


### PR DESCRIPTION

## ℹ️ Change description:
[Endless Loading Because Of Vehicle Color](https://autofleet.atlassian.net/browse/AUT-13547)
**Description**
The app is loading ~3 times on the login page.
**RCA**
On load, we have an API call to get the vehicle color, but it happened before we have the token so it failed with 401.
**Fix**
Move the logic to call this endpoint to a hook, and pass the hook in the provider, so the endpoint would be called on-demand only