### PR TITLE
Fix login failures on production builds due to late deletion of app settings

### DIFF
--- a/examples/client/Locomotion/src/pages/AuthScreens/StartScreen/index.js
+++ b/examples/client/Locomotion/src/pages/AuthScreens/StartScreen/index.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { Trans } from 'react-i18next';
+import Config from 'react-native-config';
 import logo from '../../../assets/logo.png';
 import i18n from '../../../I18n';
 import {
@@ -28,8 +29,13 @@ const StartScreen = () => {
   const { getSettingByKey } = Settings.useContainer();
   const [webViewWindow, setWebViewWindow] = useState(null);
 
-  const nextScreen = () => {
-    AppSettings.destroy();
+  const isDevSettingOn = () => Config.DEV_SETTINGS && Config.DEV_SETTINGS === 'true';
+
+  const nextScreen = async () => {
+    if (!isDevSettingOn()) {
+      await AppSettings.destroy();
+    }
+
     setUser(INITIAL_USER_STATE);
     navigationService.navigate(MAIN_ROUTES.PHONE);
   };

--- a/examples/client/Locomotion/src/pages/AuthScreens/StartScreen/index.js
+++ b/examples/client/Locomotion/src/pages/AuthScreens/StartScreen/index.js
@@ -21,12 +21,15 @@ import { INITIAL_USER_STATE } from '../AuthLoadingScreen';
 import Settings from '../../../context/settings';
 import SETTING_KEYS from '../../../context/settings/keys';
 import * as navigationService from '../../../services/navigation';
+import AppSettings from '../../../services/app-settings';
 
 const StartScreen = () => {
   const { setUser } = useContext(UserContext);
   const { getSettingByKey } = Settings.useContainer();
   const [webViewWindow, setWebViewWindow] = useState(null);
+
   const nextScreen = () => {
+    AppSettings.destroy();
     setUser(INITIAL_USER_STATE);
     navigationService.navigate(MAIN_ROUTES.PHONE);
   };

--- a/examples/client/Locomotion/src/pages/Profile/Phone.js
+++ b/examples/client/Locomotion/src/pages/Profile/Phone.js
@@ -11,7 +11,6 @@ import ScreenText from './ScreenText/index';
 import PhoneNumberInput from '../../Components/PhoneNumberInput';
 import { MAIN_ROUTES } from '../routes';
 import { UserContext } from '../../context/user';
-import AppSettings from '../../services/app-settings';
 import * as NavigationService from '../../services/navigation';
 import { PageContainer, ContentContainer } from '../styles';
 import Captcha from './Captcha';
@@ -46,9 +45,7 @@ const Phone = ({ navigation }) => {
         setIsLoadingSaveButton(false);
         return;
       }
-      if (!isDevSettingOn()) {
-        await AppSettings.destroy();
-      }
+
       await onLogin(user.phoneNumber);
       updateState({ phoneNumber: user.phoneNumber });
       nextScreen(MAIN_ROUTES.PHONE);


### PR DESCRIPTION
Due to recent Captcha changes and different `env` dev settings for `prod` and `staging/dev`, there was an error where the Captcha token is deleted from local storage due to `AppSettings.destroy()` being run when the user submits his phone number.

To fix the issue, clearing of current/stale `AppSettings` was moved to the `StartScreen` component which is higher in the stack, and also sets the `INITIAL_USER_STATE`.