### PR TITLE
Fix Android excessive CPU usage due to animated markers

### DIFF
--- a/examples/client/Locomotion/package-lock.json
+++ b/examples/client/Locomotion/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@autofleet/i18next-remote-backend-with-locals": "^1.0.0",
-        "@gorhom/bottom-sheet": "^4.3.1",
+        "@gorhom/bottom-sheet": "^4.4.7",
         "@gorhom/portal": "^1.0.14",
         "@mapbox/polyline": "^1.1.0",
         "@react-native-async-storage/async-storage": "^1.17.3",
@@ -2897,19 +2897,28 @@
       "license": "Apache-2.0"
     },
     "node_modules/@gorhom/bottom-sheet": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.4.5.tgz",
-      "integrity": "sha512-Z5Z20wshLUB8lIdtMKoJaRnjd64wBR/q8EeVPThrg+skrcBwBPHfUwZJ2srB0rEszA/01ejSJy/ixyd7Ra7vUA==",
-      "license": "MIT",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.4.7.tgz",
+      "integrity": "sha512-ukTuTqDQi2heo68hAJsBpUQeEkdqP9REBcn47OpuvPKhdPuO1RBOOADjqXJNCnZZRcY+HqbnGPMSLFVc31zylQ==",
       "dependencies": {
         "@gorhom/portal": "1.0.14",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
         "react": "*",
         "react-native": "*",
         "react-native-gesture-handler": ">=1.10.1",
         "react-native-reanimated": ">=2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gorhom/portal": {

--- a/examples/client/Locomotion/package.json
+++ b/examples/client/Locomotion/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@autofleet/i18next-remote-backend-with-locals": "^1.0.0",
-    "@gorhom/bottom-sheet": "^4.3.1",
+    "@gorhom/bottom-sheet": "^4.4.7",
     "@gorhom/portal": "^1.0.14",
     "@mapbox/polyline": "^1.1.0",
     "@react-native-async-storage/async-storage": "^1.17.3",

--- a/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
+++ b/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
@@ -2,9 +2,9 @@ import React, {
   useContext, useEffect, useState, useRef, useCallback,
 } from 'react';
 import {
-  Platform,
-} from 'react-native';
-import { MarkerAnimated, AnimatedRegion } from 'react-native-maps';
+  MarkerAnimated, AnimatedRegion, MapMarker, LatLng,
+} from 'react-native-maps';
+import { StyleProp } from 'react-native';
 import { Context as ThemeContext } from '../../context/theme';
 import SvgIcon from '../SvgIcon';
 import carIcon from '../../assets/map/Autofleet_Car_Icon.svg';
@@ -20,17 +20,28 @@ interface AvailabilityVehicleProps {
   id: string;
 }
 
+interface SvgStyle {
+  color: string,
+  transform?: { rotate: string }[]
+}
+
+/** toValue is ignored in favor of lat/lng, but required by TimingAnimationConfig interface */
+const ANIMATED_VALUE_PLACEHOLDER = 1;
+
+/** Zero delta maintains current map zoom level during marker animation */
+const MAINTAIN_CURRENT_ZOOM = 0;
+
 const DURATION = 5000;
 
 const areEqual = (
   prev: AvailabilityVehicleProps,
   next: AvailabilityVehicleProps,
 ) => prev.id === next.id
-  && prev.location.lat === next.location.lat
-  && prev.location.lng === next.location.lng
+&& prev.location.lat === next.location.lat
+&& prev.location.lng === next.location.lng
   && prev.location.bearing === next.location.bearing;
 
-const insureNumberType = (v: string | number) => {
+const ensureNumberType = (v: string | number) => {
   if (typeof v === 'string') {
     return parseFloat(v);
   }
@@ -42,31 +53,25 @@ const AvailabilityVehicle = ({
 }: AvailabilityVehicleProps) => {
   const { useVehicleColor } = useContext(ThemeContext);
   const { vehicleColor } = useVehicleColor();
-  const markerRef = useRef<MarkerAnimated>(null);
+  const markerRef = useRef<MapMarker>(null);
   const [locationAnimated] = useState(new AnimatedRegion({
-    latitude: insureNumberType(location.lat),
+    latitude: ensureNumberType(location.lat),
     latitudeDelta: 0.1,
-    longitude: insureNumberType(location.lng),
+    longitude: ensureNumberType(location.lng),
     longitudeDelta: 0.1,
   }));
 
   useEffect(() => {
     if (location.lat && location.lng) {
-      if (Platform.OS === 'android') {
-        setTimeout(() => {
-          markerRef?.current?.animateMarkerToCoordinate({
-            latitude: insureNumberType(location.lat),
-            longitude: insureNumberType(location.lng),
-          }, DURATION);
-        }, 0);
-      } else {
-        locationAnimated.timing({
-          latitude: location.lat,
-          longitude: location.lng,
-          useNativeDriver: false,
-          duration: DURATION,
-        }).start();
-      }
+      locationAnimated.timing({
+        toValue: ANIMATED_VALUE_PLACEHOLDER,
+        duration: DURATION,
+        longitudeDelta: MAINTAIN_CURRENT_ZOOM,
+        latitudeDelta: MAINTAIN_CURRENT_ZOOM,
+        useNativeDriver: false,
+        latitude: location.lat,
+        longitude: location.lng,
+      }).start();
     }
   }, [location]);
 
@@ -78,20 +83,21 @@ const AvailabilityVehicle = ({
     }
   }, [markerRef]);
 
-  const svgStyle : any = { color: vehicleColor };
+  const svgStyle: StyleProp<SvgStyle> = { color: vehicleColor };
   if (location?.bearing) {
     svgStyle.transform = [{ rotate: `${location.bearing}deg` }];
   }
+
   return (
     <MarkerAnimated
       key={id}
       ref={markerRef}
-      coordinate={locationAnimated}
+      coordinate={locationAnimated as unknown as LatLng}
       anchor={{ x: 0.5, y: 0.40 }}
       tappable={false}
       // tooltip workaround, need to upgrade library
       onPress={onPressWorkaround}
-
+      tracksViewChanges={false}
     >
       <SvgIcon
         Svg={carIcon}

--- a/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
+++ b/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
@@ -4,6 +4,7 @@ import React, {
 import {
   MarkerAnimated, AnimatedRegion, MapMarker, LatLng,
 } from 'react-native-maps';
+import { Platform } from 'react-native';
 import { Context as ThemeContext } from '../../context/theme';
 import SvgIcon from '../SvgIcon';
 import carIcon from '../../assets/map/Autofleet_Car_Icon.svg';
@@ -25,7 +26,7 @@ interface SvgStyle {
 }
 
 /** toValue is ignored in favor of lat/lng, but required by TimingAnimationConfig interface */
-const ANIMATED_VALUE_PLACEHOLDER = 1;
+const TO_VALUE_PLACEHOLDER = 1;
 
 /** Zero delta maintains current map zoom level during marker animation */
 const MAINTAIN_CURRENT_ZOOM = 0;
@@ -57,27 +58,29 @@ const AvailabilityVehicle = ({
     new AnimatedRegion({
       latitude: ensureNumberType(location.lat),
       longitude: ensureNumberType(location.lng),
-      latitudeDelta: MAINTAIN_CURRENT_ZOOM,
-      longitudeDelta: MAINTAIN_CURRENT_ZOOM,
+      latitudeDelta: 0.1,
+      longitudeDelta: 0.1,
     }),
   );
 
   useEffect(() => {
     if (location.lat && location.lng) {
       locationAnimationRef.current.timing({
-        toValue: ANIMATED_VALUE_PLACEHOLDER,
+        toValue: TO_VALUE_PLACEHOLDER,
         duration: DURATION,
         longitudeDelta: MAINTAIN_CURRENT_ZOOM,
         latitudeDelta: MAINTAIN_CURRENT_ZOOM,
         useNativeDriver: false,
-        latitude: location.lat,
-        longitude: location.lng,
+        latitude: ensureNumberType(location.lat),
+        longitude: ensureNumberType(location.lng),
       }).start();
     }
-  }, [location]);
+  }, [location?.lat, location?.lng]);
 
   useEffect(() => {
-    markerRef.current?.redraw();
+    if (Platform.OS === 'android') {
+      markerRef.current?.redraw();
+    }
   }, [vehicleColor, markerRef.current, location?.bearing]);
 
   const onPressWorkaround = useCallback(() => {

--- a/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
+++ b/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
@@ -76,6 +76,10 @@ const AvailabilityVehicle = ({
     }
   }, [location]);
 
+  useEffect(() => {
+    markerRef.current?.redraw();
+  }, [vehicleColor, markerRef.current, location?.bearing]);
+
   const onPressWorkaround = useCallback(() => {
     try {
       markerRef?.current?.hideCallout();

--- a/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
+++ b/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
@@ -4,7 +4,6 @@ import React, {
 import {
   MarkerAnimated, AnimatedRegion, MapMarker, LatLng,
 } from 'react-native-maps';
-import { StyleProp } from 'react-native';
 import { Context as ThemeContext } from '../../context/theme';
 import SvgIcon from '../SvgIcon';
 import carIcon from '../../assets/map/Autofleet_Car_Icon.svg';
@@ -83,7 +82,7 @@ const AvailabilityVehicle = ({
     }
   }, [markerRef]);
 
-  const svgStyle: StyleProp<SvgStyle> = { color: vehicleColor };
+  const svgStyle: SvgStyle = { color: vehicleColor };
   if (location?.bearing) {
     svgStyle.transform = [{ rotate: `${location.bearing}deg` }];
   }

--- a/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
+++ b/examples/client/Locomotion/src/Components/AvailabilityVehicle/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useContext, useEffect, useState, useRef, useCallback,
+  useContext, useEffect, useRef, useCallback,
 } from 'react';
 import {
   MarkerAnimated, AnimatedRegion, MapMarker, LatLng,
@@ -53,16 +53,18 @@ const AvailabilityVehicle = ({
   const { useVehicleColor } = useContext(ThemeContext);
   const { vehicleColor } = useVehicleColor();
   const markerRef = useRef<MapMarker>(null);
-  const [locationAnimated] = useState(new AnimatedRegion({
-    latitude: ensureNumberType(location.lat),
-    latitudeDelta: 0.1,
-    longitude: ensureNumberType(location.lng),
-    longitudeDelta: 0.1,
-  }));
+  const locationAnimationRef = useRef<AnimatedRegion>(
+    new AnimatedRegion({
+      latitude: ensureNumberType(location.lat),
+      longitude: ensureNumberType(location.lng),
+      latitudeDelta: MAINTAIN_CURRENT_ZOOM,
+      longitudeDelta: MAINTAIN_CURRENT_ZOOM,
+    }),
+  );
 
   useEffect(() => {
     if (location.lat && location.lng) {
-      locationAnimated.timing({
+      locationAnimationRef.current.timing({
         toValue: ANIMATED_VALUE_PLACEHOLDER,
         duration: DURATION,
         longitudeDelta: MAINTAIN_CURRENT_ZOOM,
@@ -91,7 +93,7 @@ const AvailabilityVehicle = ({
     <MarkerAnimated
       key={id}
       ref={markerRef}
-      coordinate={locationAnimated as unknown as LatLng}
+      coordinate={locationAnimationRef.current as unknown as LatLng}
       anchor={{ x: 0.5, y: 0.40 }}
       tappable={false}
       // tooltip workaround, need to upgrade library
@@ -105,7 +107,6 @@ const AvailabilityVehicle = ({
         style={svgStyle}
       />
     </MarkerAnimated>
-
   );
 };
 


### PR DESCRIPTION
# Summary
Custom animated markers cause excessive CPU usage on Android devices. This can be solved by setting `tracksViewChanges` to `false`, which disables the Marker automatically animating its position, which is CPU intensive.
Instead, we manually animate the Markers position using `AnimationRegion`.
In addition, there are some TS improvements and typo fixes.