### PR TITLE
AUT-25412: Add `External` payment method

### DIFF
--- a/examples/client/Locomotion/src/Components/CardRow/index.tsx
+++ b/examples/client/Locomotion/src/Components/CardRow/index.tsx
@@ -135,16 +135,16 @@ const CardRow = (paymentMethod: any) => {
   }, [paymentMethod]);
 
   const prefix = paymentMethod.testIdPrefix || '';
-  const { id, addNew } = paymentMethod;
+  const { paymentMethodId, addNew } = paymentMethod;
   const isSpecialMethod = [
     PAYMENT_METHODS.OFFLINE,
     PAYMENT_METHODS.CASH,
     PAYMENT_METHODS.EXTERNAL,
-  ].includes(id);
+  ].includes(paymentMethodId);
 
   const testID = addNew
     ? `${prefix}AddPaymentMethod`
-    : `${prefix}ChoosePaymentMethod${isSpecialMethod ? `_${id}` : ''}`;
+    : `${prefix}ChoosePaymentMethod${isSpecialMethod ? `_${paymentMethodId}` : ''}`;
 
   const getPaymentMethodIcon = () => {
     if (paymentMethod.noSvg) {

--- a/examples/client/Locomotion/src/Components/CardRow/index.tsx
+++ b/examples/client/Locomotion/src/Components/CardRow/index.tsx
@@ -14,7 +14,7 @@ import SvgIcon from '../SvgIcon';
 import selected from '../../assets/selected-v.svg';
 import { Start, StartCapital } from '../../lib/text-direction';
 import chevronIcon from '../../assets/chevron.svg';
-import { isCashPaymentMethod, isOfflinePaymentMethod } from '../../lib/ride/utils';
+import { isCashPaymentMethod, isExternalPaymentMethod, isOfflinePaymentMethod } from '../../lib/ride/utils';
 import paymentContext from '../../context/payments';
 
 type ContainerProps = {
@@ -107,12 +107,19 @@ const CardRow = (paymentMethod: any) => {
       const { name } = getBusinessAccountById(businessAccountId);
       return name;
     }
+
     if (isCashPaymentMethod(paymentMethod)) {
       return i18n.t('payments.cash');
     }
+
     if (isOfflinePaymentMethod(paymentMethod)) {
       return offlinePaymentText;
     }
+
+    if (isExternalPaymentMethod(paymentMethod)) {
+      return i18n.t('payments.external');
+    }
+
     return capitalizeFirstLetter(paymentMethod.name);
   };
 
@@ -127,8 +134,16 @@ const CardRow = (paymentMethod: any) => {
     }, 100);
   }, [paymentMethod]);
   const testID = paymentMethod.addNew
-    ? `${paymentMethod.testIdPrefix || ''}AddPaymentMethod`
-    : (`${paymentMethod.testIdPrefix || ''}ChoosePaymentMethod${paymentMethod.id === PAYMENT_METHODS.OFFLINE || paymentMethod.id === PAYMENT_METHODS.CASH ? `_${paymentMethod.id}` : ''}`);
+      ? `${paymentMethod.testIdPrefix || ''}AddPaymentMethod`
+      : (
+          `${paymentMethod.testIdPrefix || ''}ChoosePaymentMethod${
+              paymentMethod.id === PAYMENT_METHODS.OFFLINE
+              || paymentMethod.id === PAYMENT_METHODS.CASH
+              || paymentMethod.id === PAYMENT_METHODS.EXTERNAL
+                  ? `_${paymentMethod.id}`
+                  : ''
+          }`
+      );
 
   const getPaymentMethodIcon = () => {
     if (paymentMethod.noSvg) {

--- a/examples/client/Locomotion/src/Components/CardRow/index.tsx
+++ b/examples/client/Locomotion/src/Components/CardRow/index.tsx
@@ -133,17 +133,18 @@ const CardRow = (paymentMethod: any) => {
       setIsCardExpired(isExpired);
     }, 100);
   }, [paymentMethod]);
-  const testID = paymentMethod.addNew
-    ? `${paymentMethod.testIdPrefix || ''}AddPaymentMethod`
-    : (
-      `${paymentMethod.testIdPrefix || ''}ChoosePaymentMethod${
-        paymentMethod.id === PAYMENT_METHODS.OFFLINE
-              || paymentMethod.id === PAYMENT_METHODS.CASH
-              || paymentMethod.id === PAYMENT_METHODS.EXTERNAL
-          ? `_${paymentMethod.id}`
-          : ''
-      }`
-    );
+
+  const prefix = paymentMethod.testIdPrefix || '';
+  const { id, addNew } = paymentMethod;
+  const isSpecialMethod = [
+    PAYMENT_METHODS.OFFLINE,
+    PAYMENT_METHODS.CASH,
+    PAYMENT_METHODS.EXTERNAL,
+  ].includes(id);
+
+  const testID = addNew
+      ? `${prefix}AddPaymentMethod`
+      : `${prefix}ChoosePaymentMethod${isSpecialMethod ? `_${id}` : ''}`;
 
   const getPaymentMethodIcon = () => {
     if (paymentMethod.noSvg) {

--- a/examples/client/Locomotion/src/Components/CardRow/index.tsx
+++ b/examples/client/Locomotion/src/Components/CardRow/index.tsx
@@ -134,16 +134,16 @@ const CardRow = (paymentMethod: any) => {
     }, 100);
   }, [paymentMethod]);
   const testID = paymentMethod.addNew
-      ? `${paymentMethod.testIdPrefix || ''}AddPaymentMethod`
-      : (
-          `${paymentMethod.testIdPrefix || ''}ChoosePaymentMethod${
-              paymentMethod.id === PAYMENT_METHODS.OFFLINE
+    ? `${paymentMethod.testIdPrefix || ''}AddPaymentMethod`
+    : (
+      `${paymentMethod.testIdPrefix || ''}ChoosePaymentMethod${
+        paymentMethod.id === PAYMENT_METHODS.OFFLINE
               || paymentMethod.id === PAYMENT_METHODS.CASH
               || paymentMethod.id === PAYMENT_METHODS.EXTERNAL
-                  ? `_${paymentMethod.id}`
-                  : ''
-          }`
-      );
+          ? `_${paymentMethod.id}`
+          : ''
+      }`
+    );
 
   const getPaymentMethodIcon = () => {
     if (paymentMethod.noSvg) {

--- a/examples/client/Locomotion/src/Components/CardRow/index.tsx
+++ b/examples/client/Locomotion/src/Components/CardRow/index.tsx
@@ -143,8 +143,8 @@ const CardRow = (paymentMethod: any) => {
   ].includes(id);
 
   const testID = addNew
-      ? `${prefix}AddPaymentMethod`
-      : `${prefix}ChoosePaymentMethod${isSpecialMethod ? `_${id}` : ''}`;
+    ? `${prefix}AddPaymentMethod`
+    : `${prefix}ChoosePaymentMethod${isSpecialMethod ? `_${id}` : ''}`;
 
   const getPaymentMethodIcon = () => {
     if (paymentMethod.noSvg) {

--- a/examples/client/Locomotion/src/Components/RideCard/index.tsx
+++ b/examples/client/Locomotion/src/Components/RideCard/index.tsx
@@ -13,6 +13,7 @@ import StopPointsVerticalView from '../StopPointsVerticalView';
 import { getFormattedPrice, isPriceEstimated, convertTimezoneByLocation } from '../../context/newRideContext/utils';
 import cashIcon from '../../assets/cash.svg';
 import offlineIcon from '../../assets/offline.svg';
+import placeholderIcon from '../../assets/placeholder-payment.svg';
 import { PAYMENT_METHODS } from '../../pages/Payments/consts';
 import PaymentContext from '../../context/payments';
 import SettingContext from '../../context/settings';
@@ -31,6 +32,7 @@ interface CardComponentProps {
 const CardComponent = ({ paymentMethod, businessAccountId }: CardComponentProps) => {
   const isCash = PAYMENT_METHODS.CASH === paymentMethod.id;
   const isOffline = PAYMENT_METHODS.OFFLINE === paymentMethod.id;
+  const isExternal = PAYMENT_METHODS.EXTERNAL === paymentMethod.id;
   const {
     offlinePaymentText,
     loadOfflinePaymentText,
@@ -51,6 +53,10 @@ const CardComponent = ({ paymentMethod, businessAccountId }: CardComponentProps)
     } if (isOffline) {
       return offlinePaymentText;
     }
+    if (isExternal) {
+      return i18n.t('payments.external');
+    }
+
     return paymentMethod.name;
   };
 
@@ -61,7 +67,11 @@ const CardComponent = ({ paymentMethod, businessAccountId }: CardComponentProps)
     if (isOffline) {
       return offlineIcon;
     }
+    if (isExternal) {
+      return placeholderIcon;
+    }
   };
+
   return (
     <TextRowWithIcon
       text={getText() || ''}

--- a/examples/client/Locomotion/src/Components/RideCard/index.tsx
+++ b/examples/client/Locomotion/src/Components/RideCard/index.tsx
@@ -18,7 +18,7 @@ import PaymentContext from '../../context/payments';
 import SettingContext from '../../context/settings';
 import showPriceBasedOnAccount from '../../services/showPriceBasedOnAccount';
 import { RideDateSkeleton } from './Skeleton/RideDateSkeleton';
-
+import  defaultPaymentIcon from '../../assets/default-payment.svg';
 
 interface CardComponentProps {
   paymentMethod: {
@@ -67,7 +67,7 @@ const CardComponent = ({ paymentMethod, businessAccountId }: CardComponentProps)
       return offlineIcon;
     }
     if (isExternal) {
-      return PaymentIcon;
+      return defaultPaymentIcon;
     }
   };
 

--- a/examples/client/Locomotion/src/Components/RideCard/index.tsx
+++ b/examples/client/Locomotion/src/Components/RideCard/index.tsx
@@ -13,7 +13,6 @@ import StopPointsVerticalView from '../StopPointsVerticalView';
 import { getFormattedPrice, isPriceEstimated, convertTimezoneByLocation } from '../../context/newRideContext/utils';
 import cashIcon from '../../assets/cash.svg';
 import offlineIcon from '../../assets/offline.svg';
-import placeholderIcon from '../../assets/placeholder-payment.svg';
 import { PAYMENT_METHODS } from '../../pages/Payments/consts';
 import PaymentContext from '../../context/payments';
 import SettingContext from '../../context/settings';
@@ -68,7 +67,7 @@ const CardComponent = ({ paymentMethod, businessAccountId }: CardComponentProps)
       return offlineIcon;
     }
     if (isExternal) {
-      return placeholderIcon;
+      return PaymentIcon;
     }
   };
 

--- a/examples/client/Locomotion/src/Components/RideCard/index.tsx
+++ b/examples/client/Locomotion/src/Components/RideCard/index.tsx
@@ -18,7 +18,7 @@ import PaymentContext from '../../context/payments';
 import SettingContext from '../../context/settings';
 import showPriceBasedOnAccount from '../../services/showPriceBasedOnAccount';
 import { RideDateSkeleton } from './Skeleton/RideDateSkeleton';
-import  defaultPaymentIcon from '../../assets/default-payment.svg';
+import defaultPaymentIcon from '../../assets/default-payment.svg';
 
 interface CardComponentProps {
   paymentMethod: {

--- a/examples/client/Locomotion/src/I18n/en.json
+++ b/examples/client/Locomotion/src/I18n/en.json
@@ -536,6 +536,7 @@
         "setPaymentBanner": "Set payment method",
         "payWithCash": "Pay with Cash",
         "cash": "Cash",
+        "external": "External",
         "offline": "Billed to company",
         "popups": {
             "removeCard": {

--- a/examples/client/Locomotion/src/assets/default-payment.svg
+++ b/examples/client/Locomotion/src/assets/default-payment.svg
@@ -1,0 +1,14 @@
+<svg
+        data-autofleet-icon="true"
+        role="img"
+        aria-hidden="true"
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        class="SvgContainer-NcZRl bLZmUO"
+>
+    <path
+            fill-rule="evenodd"
+            d="M3 18c0 .5523.4477 1 1 1H20c.5523 0 1-.4477 1-1V10H3v8ZM21 8V9H3V8H21ZM20 5c.5523 0 1 .4477 1 1V7H3V6c0-.5523.4477-1 1-1H20ZM4 4H20c1.1046 0 2 .8954 2 2V18c0 1.1046-.8954 2-2 2H4c-1.1046 0-2-.8954-2-2V6c0-1.1046.8954-2 2-2ZM7 16H6V13H7v3Zm2-3H8v3H9V13Zm2 3H10V13h1v3Zm2-3H12v3h1V13Z"
+    />
+</svg>

--- a/examples/client/Locomotion/src/assets/placeholder-payment.svg
+++ b/examples/client/Locomotion/src/assets/placeholder-payment.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" fill="none"/>
+</svg>

--- a/examples/client/Locomotion/src/assets/placeholder-payment.svg
+++ b/examples/client/Locomotion/src/assets/placeholder-payment.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="24" height="24" fill="none"/>
-</svg>

--- a/examples/client/Locomotion/src/lib/commonTypes/index.ts
+++ b/examples/client/Locomotion/src/lib/commonTypes/index.ts
@@ -22,6 +22,7 @@ export const PAYMENT_METHODS = {
   CASH: 'cash',
   CARD: 'card',
   OFFLINE: 'offline',
+  EXTERNAL: 'external',
   APPLE_PAY: 'apple-pay',
   GOOGLE_PAY: 'google-pay',
 };

--- a/examples/client/Locomotion/src/lib/ride/utils.ts
+++ b/examples/client/Locomotion/src/lib/ride/utils.ts
@@ -47,4 +47,6 @@ export const isCashPaymentMethod = (paymentMethod: any) => paymentMethod?.id ===
 
 export const isOfflinePaymentMethod = (paymentMethod: any) => paymentMethod?.id === PAYMENT_METHODS.OFFLINE;
 
-export const isCardPaymentMethod = (paymentMethod: any) => ![PAYMENT_METHODS.CASH, PAYMENT_METHODS.OFFLINE].includes(paymentMethod?.id);
+export const isCardPaymentMethod = (paymentMethod: any) => ![PAYMENT_METHODS.CASH, PAYMENT_METHODS.OFFLINE, PAYMENT_METHODS.EXTERNAL].includes(paymentMethod?.id);
+
+export const isExternalPaymentMethod = (paymentMethod: any) => paymentMethod?.id === PAYMENT_METHODS.EXTERNAL;

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/PaymentButton/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/PaymentButton/index.tsx
@@ -5,7 +5,12 @@ import { Text, View } from 'react-native';
 import { PaymentIcon } from 'react-native-payment-icons';
 import styled, { ThemeContext } from 'styled-components';
 import { useFocusEffect } from '@react-navigation/native';
-import { isCardPaymentMethod, isCashPaymentMethod, isOfflinePaymentMethod } from '../../../../../../lib/ride/utils';
+import {
+  isCardPaymentMethod,
+  isCashPaymentMethod,
+  isExternalPaymentMethod,
+  isOfflinePaymentMethod
+} from '../../../../../../lib/ride/utils';
 import { getCouponText } from '../../../../../../context/newRideContext/utils';
 import { MAIN_ROUTES } from '../../../../../routes';
 import SvgIcon from '../../../../../../Components/SvgIcon';
@@ -95,7 +100,7 @@ const PaymentButton = ({
     : i18n.t('bottomSheetContent.ride.promoText'));
 
   const loadPromoButton = () => {
-    if (isCashPaymentMethod({ id }) || isOfflinePaymentMethod({ id })) {
+    if (isCashPaymentMethod({ id }) || isOfflinePaymentMethod({ id }) || isExternalPaymentMethod({ id })) {
       return null;
     }
 

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/PaymentButton/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/PaymentButton/index.tsx
@@ -9,7 +9,7 @@ import {
   isCardPaymentMethod,
   isCashPaymentMethod,
   isExternalPaymentMethod,
-  isOfflinePaymentMethod
+  isOfflinePaymentMethod,
 } from '../../../../../../lib/ride/utils';
 import { getCouponText } from '../../../../../../context/newRideContext/utils';
 import { MAIN_ROUTES } from '../../../../../routes';

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
@@ -5,7 +5,7 @@ import DatePicker from 'react-native-date-picker';
 import moment from 'moment';
 import { ThemeContext } from 'styled-components';
 import { Animated } from 'react-native';
-import { isCashPaymentMethod, isOfflinePaymentMethod } from '../../../../../lib/ride/utils';
+import { isCashPaymentMethod, isExternalPaymentMethod, isOfflinePaymentMethod } from '../../../../../lib/ride/utils';
 import DatePickerPoppup from '../../../../../popups/DatePickerPoppup';
 import FutureBookingButton from './FutureBookingButton';
 import {
@@ -32,6 +32,7 @@ import { PAYMENT_METHODS, paymentMethodToIconMap } from '../../../../../pages/Pa
 import PassengersCounter from './PassengersCounter';
 import ErrorPopup from '../../../../../popups/TwoButtonPopup';
 import { capitalizeFirstLetter, getPaymentMethod } from '../../../../../pages/Payments/cardDetailUtils';
+import externalPaymentMethod from '../../../../../pages/Payments/externalPaymentMethod';
 
 const POOLING_TYPES = {
   NO: 'no',
@@ -226,6 +227,7 @@ const RideButtons = ({
   const paymentMethodIdToDataMap = {
     [PAYMENT_METHODS.CASH]: cashPaymentMethod,
     [PAYMENT_METHODS.OFFLINE]: offlinePaymentMethod,
+    [PAYMENT_METHODS.EXTERNAL]: externalPaymentMethod,
   };
   const renderPaymentButton = () => {
     const {
@@ -251,6 +253,9 @@ const RideButtons = ({
       }
       if (isOfflinePaymentMethod(selectedPaymentMethod)) {
         return offlinePaymentText;
+      }
+      if (isExternalPaymentMethod(selectedPaymentMethod)) {
+        return i18n.t('payments.external');
       }
 
       return selectedPaymentMethod?.name || i18n.t('bottomSheetContent.ride.addPayment');

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
@@ -32,7 +32,7 @@ import { PAYMENT_METHODS, paymentMethodToIconMap } from '../../../../../pages/Pa
 import PassengersCounter from './PassengersCounter';
 import ErrorPopup from '../../../../../popups/TwoButtonPopup';
 import { capitalizeFirstLetter, getPaymentMethod } from '../../../../../pages/Payments/cardDetailUtils';
-import externalPaymentMethod from '../../../../../pages/Payments/externalPaymentMethod';
+import { externalPaymentMethod } from '../../../../../pages/Payments/externalPaymentMethod';
 
 const POOLING_TYPES = {
   NO: 'no',

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/index.tsx
@@ -54,6 +54,7 @@ const RideOptions = () => {
     ?.map((se: any) => se.allowedPaymentMethods).flat());
   const showCash = allServicesPaymentMethods.has(PAYMENT_METHODS.CASH);
   const showOffline = allServicesPaymentMethods.has(PAYMENT_METHODS.OFFLINE);
+  const showExternal = allServicesPaymentMethods.has(PAYMENT_METHODS.EXTERNAL);
 
   useEffect(() => {
     const updateDefaultPaymentMethod = async () => {
@@ -123,6 +124,7 @@ const RideOptions = () => {
           }}
           showCash={showCash}
           showOffline={showOffline}
+          showExternal={showExternal}
           selected={ride?.paymentMethodId || defaultPaymentMethod?.id}
           rideFlow
           isVisible={popupToShow === 'payment'}

--- a/examples/client/Locomotion/src/pages/Payments/consts.ts
+++ b/examples/client/Locomotion/src/pages/Payments/consts.ts
@@ -1,6 +1,6 @@
 import cashIcon from '../../assets/cash.svg';
 import offlineIcon from '../../assets/offline.svg';
-import { PaymentIcon } from 'react-native-payment-icons';
+import  defaultPaymentIcon from '../../assets/default-payment.svg';
 import personalPaymentIcon from '../../assets/personal-payment.svg';
 import businessPaymentIcon from '../../assets/business-payment.svg';
 
@@ -29,5 +29,5 @@ export const PAYMENT_TABS = [
 export const paymentMethodToIconMap = {
   [PAYMENT_METHODS.CASH]: cashIcon,
   [PAYMENT_METHODS.OFFLINE]: offlineIcon,
-  [PAYMENT_METHODS.EXTERNAL]: PaymentIcon,
+  [PAYMENT_METHODS.EXTERNAL]: defaultPaymentIcon,
 };

--- a/examples/client/Locomotion/src/pages/Payments/consts.ts
+++ b/examples/client/Locomotion/src/pages/Payments/consts.ts
@@ -1,6 +1,6 @@
 import cashIcon from '../../assets/cash.svg';
 import offlineIcon from '../../assets/offline.svg';
-import  defaultPaymentIcon from '../../assets/default-payment.svg';
+import defaultPaymentIcon from '../../assets/default-payment.svg';
 import personalPaymentIcon from '../../assets/personal-payment.svg';
 import businessPaymentIcon from '../../assets/business-payment.svg';
 

--- a/examples/client/Locomotion/src/pages/Payments/consts.ts
+++ b/examples/client/Locomotion/src/pages/Payments/consts.ts
@@ -1,6 +1,6 @@
 import cashIcon from '../../assets/cash.svg';
 import offlineIcon from '../../assets/offline.svg';
-import placeholderIcon from '../../assets/placeholder-payment.svg';
+import { PaymentIcon } from 'react-native-payment-icons';
 import personalPaymentIcon from '../../assets/personal-payment.svg';
 import businessPaymentIcon from '../../assets/business-payment.svg';
 
@@ -29,5 +29,5 @@ export const PAYMENT_TABS = [
 export const paymentMethodToIconMap = {
   [PAYMENT_METHODS.CASH]: cashIcon,
   [PAYMENT_METHODS.OFFLINE]: offlineIcon,
-  [PAYMENT_METHODS.EXTERNAL]: placeholderIcon,
+  [PAYMENT_METHODS.EXTERNAL]: PaymentIcon,
 };

--- a/examples/client/Locomotion/src/pages/Payments/consts.ts
+++ b/examples/client/Locomotion/src/pages/Payments/consts.ts
@@ -1,5 +1,6 @@
 import cashIcon from '../../assets/cash.svg';
 import offlineIcon from '../../assets/offline.svg';
+import placeholderIcon from '../../assets/placeholder-payment.svg';
 import personalPaymentIcon from '../../assets/personal-payment.svg';
 import businessPaymentIcon from '../../assets/business-payment.svg';
 
@@ -7,6 +8,7 @@ export const PAYMENT_METHODS = {
   CASH: 'cash',
   OFFLINE: 'offline',
   CARD: 'card',
+  EXTERNAL: 'external',
 };
 export const PAYMENT_MODES = {
   PERSONAL: 'personal',
@@ -27,4 +29,5 @@ export const PAYMENT_TABS = [
 export const paymentMethodToIconMap = {
   [PAYMENT_METHODS.CASH]: cashIcon,
   [PAYMENT_METHODS.OFFLINE]: offlineIcon,
+  [PAYMENT_METHODS.EXTERNAL]: placeholderIcon,
 };

--- a/examples/client/Locomotion/src/pages/Payments/externalPaymentMethod.ts
+++ b/examples/client/Locomotion/src/pages/Payments/externalPaymentMethod.ts
@@ -1,22 +1,22 @@
 import { PaymentMethodInterface } from 'context/payments/interface';
-import { PAYMENT_METHODS } from './consts';
 import i18n from 'i18next';
+import { PAYMENT_METHODS } from './consts';
 
 const externalPaymentMethod : PaymentMethodInterface = {
-    brand: 'generic',
-    createdAt: new Date(),
-    customerId: '',
-    expiresAt: new Date(2100, 9, 9),
-    hasOutstandingBalance: false,
-    id: PAYMENT_METHODS.EXTERNAL,
-    isDefault: false,
-    isExpired: false,
-    lastFour: '',
-    name: i18n.t('payments.external'),
-    stripeId: '',
-    updatedAt: new Date(),
-    deletedAt: null,
-    outstandingBalance: { amount: 0, currency: 'USD' },
+  brand: 'generic',
+  createdAt: new Date(),
+  customerId: '',
+  expiresAt: new Date(2100, 9, 9),
+  hasOutstandingBalance: false,
+  id: PAYMENT_METHODS.EXTERNAL,
+  isDefault: false,
+  isExpired: false,
+  lastFour: '',
+  name: i18n.t('payments.external'),
+  stripeId: '',
+  updatedAt: new Date(),
+  deletedAt: null,
+  outstandingBalance: { amount: 0, currency: 'USD' },
 };
 
 export default externalPaymentMethod;

--- a/examples/client/Locomotion/src/pages/Payments/externalPaymentMethod.ts
+++ b/examples/client/Locomotion/src/pages/Payments/externalPaymentMethod.ts
@@ -1,0 +1,22 @@
+import { PaymentMethodInterface } from 'context/payments/interface';
+import { PAYMENT_METHODS } from './consts';
+import i18n from 'i18next';
+
+const externalPaymentMethod : PaymentMethodInterface = {
+    brand: 'generic',
+    createdAt: new Date(),
+    customerId: '',
+    expiresAt: new Date(2100, 9, 9),
+    hasOutstandingBalance: false,
+    id: PAYMENT_METHODS.EXTERNAL,
+    isDefault: false,
+    isExpired: false,
+    lastFour: '',
+    name: i18n.t('payments.external'),
+    stripeId: '',
+    updatedAt: new Date(),
+    deletedAt: null,
+    outstandingBalance: { amount: 0, currency: 'USD' },
+};
+
+export default externalPaymentMethod;

--- a/examples/client/Locomotion/src/pages/Payments/externalPaymentMethod.ts
+++ b/examples/client/Locomotion/src/pages/Payments/externalPaymentMethod.ts
@@ -2,7 +2,7 @@ import { PaymentMethodInterface } from 'context/payments/interface';
 import i18n from 'i18next';
 import { PAYMENT_METHODS } from './consts';
 
-const externalPaymentMethod : PaymentMethodInterface = {
+export const externalPaymentMethod : PaymentMethodInterface = {
   brand: 'generic',
   createdAt: new Date(),
   customerId: '',
@@ -18,5 +18,3 @@ const externalPaymentMethod : PaymentMethodInterface = {
   deletedAt: null,
   outstandingBalance: { amount: 0, currency: 'USD' },
 };
-
-export default externalPaymentMethod;

--- a/examples/client/Locomotion/src/popups/ChoosePaymentMethod/index.tsx
+++ b/examples/client/Locomotion/src/popups/ChoosePaymentMethod/index.tsx
@@ -68,7 +68,7 @@ const PaymentMethodPopup = ({
   const personalPaymentMethods = [
     ...usePayments.paymentMethods,
     ...(showCash ? [cashPaymentMethod] : []),
-    ...(showOffline? [offlinePaymentMethod]: []),
+    ...(showOffline ? [offlinePaymentMethod] : []),
     ...(showExternal ? [externalPaymentMethod] : []),
   ];
 

--- a/examples/client/Locomotion/src/popups/ChoosePaymentMethod/index.tsx
+++ b/examples/client/Locomotion/src/popups/ChoosePaymentMethod/index.tsx
@@ -25,6 +25,8 @@ import PaymentMethod from '../../Components/CardRow';
 import PaymentsContext from '../../context/payments';
 import cashPaymentMethod from '../../pages/Payments/cashPaymentMethod';
 import offlinePaymentMethod from '../../pages/Payments/offlinePaymentMethod';
+import externalPaymentMethod from '../../pages/Payments/externalPaymentMethod';
+
 import * as navigationService from '../../services/navigation';
 import { NewRidePageContext } from '../../context';
 
@@ -37,6 +39,7 @@ interface PaymentMethodPopupProps {
   selected: any;
   onAddNewMethod: () => void;
   showOffline: boolean;
+  showExternal: boolean;
   showBusinessPaymentMethods: boolean;
   selectedBusinessAccountId: string | null;
 }
@@ -50,6 +53,7 @@ const PaymentMethodPopup = ({
   selected,
   onAddNewMethod,
   showOffline,
+  showExternal,
   showBusinessPaymentMethods,
   selectedBusinessAccountId,
 }: PaymentMethodPopupProps) => {
@@ -64,7 +68,8 @@ const PaymentMethodPopup = ({
   const personalPaymentMethods = [
     ...usePayments.paymentMethods,
     ...(showCash ? [cashPaymentMethod] : []),
-    ...(showOffline ? [offlinePaymentMethod] : []),
+    ...(showOffline? [offlinePaymentMethod]: []),
+    ...(showExternal ? [externalPaymentMethod] : []),
   ];
 
   const getDisabledReason = (paymentMethod: any) => {
@@ -242,6 +247,7 @@ PaymentMethodPopup.propTypes = {
   rideFlow: PropTypes.bool,
   selected: PropTypes.string,
   showOffline: PropTypes.bool,
+  showExternal: PropTypes.bool,
 };
 
 PaymentMethodPopup.defaultProps = {
@@ -250,6 +256,7 @@ PaymentMethodPopup.defaultProps = {
   rideFlow: false,
   selected: null,
   showOffline: false,
+  showExternal: false,
 };
 
 export default PaymentMethodPopup;

--- a/examples/client/Locomotion/src/popups/ChoosePaymentMethod/index.tsx
+++ b/examples/client/Locomotion/src/popups/ChoosePaymentMethod/index.tsx
@@ -25,7 +25,7 @@ import PaymentMethod from '../../Components/CardRow';
 import PaymentsContext from '../../context/payments';
 import cashPaymentMethod from '../../pages/Payments/cashPaymentMethod';
 import offlinePaymentMethod from '../../pages/Payments/offlinePaymentMethod';
-import externalPaymentMethod from '../../pages/Payments/externalPaymentMethod';
+import { externalPaymentMethod } from '../../pages/Payments/externalPaymentMethod';
 
 import * as navigationService from '../../services/navigation';
 import { NewRidePageContext } from '../../context';


### PR DESCRIPTION
The currently supported payment methods are cash, offline, and credit card.
The task is to add an external payment method.

This includes updating all payment screens where payment options are displayed, such as the main flow when ordering a ride, scheduling future rides, etc.

The external payment method should not be displayed in the payment section of the hamburger menu.

This option is already supported in the Control Center through a configuration flag.
In Locomotion, it will be presented according to the service definition.