### PR TITLE
Fix `MainCardForm` causing a screen freeze

### DIFF
--- a/examples/client/Locomotion/src/Components/NewCreditForm/index.js
+++ b/examples/client/Locomotion/src/Components/NewCreditForm/index.js
@@ -72,7 +72,7 @@ const NewCreditForm = ({ onDone, canSkip = false, PageText }) => {
           }}
           style={{
             width: '100%',
-            height: 170,
+            height: 300,
             border: 0,
           }}
           onFormComplete={(cardDetails) => {

--- a/examples/client/Locomotion/src/Components/NewCreditForm/index.js
+++ b/examples/client/Locomotion/src/Components/NewCreditForm/index.js
@@ -3,13 +3,11 @@ import {
   CardForm as MainCardForm,
   useStripe,
 } from '@stripe/stripe-react-native';
-import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import i18n from '../../I18n';
 import PaymentsContext from '../../context/payments';
 import SubmitButton from '../RoundedButton';
-import {
-  CreditForm, ErrorMessage, SkipSubmitContainer, SubmitContainer, MainCardFormContainer,
-} from './styled';
+import { ErrorMessage, SkipSubmitContainer, SubmitContainer } from './styled';
 import { Context as ThemeContext } from '../../context/theme';
 import { getInputIsoCode } from '../../services/MccMnc';
 
@@ -60,7 +58,7 @@ const NewCreditForm = ({ onDone, canSkip = false, PageText }) => {
 
   return (
     <ScrollView keyboardShouldPersistTaps="handle">
-      <CreditForm>
+      <View>
         <PageText />
         <MainCardForm
           autofocus
@@ -74,7 +72,7 @@ const NewCreditForm = ({ onDone, canSkip = false, PageText }) => {
           }}
           style={{
             width: '100%',
-            height: 300,
+            height: 170,
             border: 0,
           }}
           onFormComplete={(cardDetails) => {
@@ -89,30 +87,23 @@ const NewCreditForm = ({ onDone, canSkip = false, PageText }) => {
           }}
         />
         <ErrorMessage>{errorMessage}</ErrorMessage>
-      </CreditForm>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={100}
-      >
-        <SubmitContainer>
-          {canSkip && (
-            <SkipSubmitContainer>
-              <SubmitButton onPress={() => onDone()} disabled={loading}>
-                {i18n.t('payments.skipForNow')}
-              </SubmitButton>
-            </SkipSubmitContainer>
-          )}
-          <SubmitButton
-            testID="submitCardButton"
-            onPress={() => handlePayPress()}
-            disabled={!formReady || loading}
-          >
-            {i18n.t('payments.submitCard')}
-          </SubmitButton>
-        </SubmitContainer>
-
-      </KeyboardAvoidingView>
-
+      </View>
+      <SubmitContainer>
+        {canSkip && (
+          <SkipSubmitContainer>
+            <SubmitButton onPress={() => onDone()} disabled={loading}>
+              {i18n.t('payments.skipForNow')}
+            </SubmitButton>
+          </SkipSubmitContainer>
+        )}
+        <SubmitButton
+          testID="submitCardButton"
+          onPress={() => handlePayPress()}
+          disabled={!formReady || loading}
+        >
+          {i18n.t('payments.submitCard')}
+        </SubmitButton>
+      </SubmitContainer>
     </ScrollView>
   );
 };

--- a/examples/client/Locomotion/src/Components/NewCreditForm/styled.js
+++ b/examples/client/Locomotion/src/Components/NewCreditForm/styled.js
@@ -6,10 +6,6 @@ export const SkipSubmitContainer = styled.View`
 
 export const SubmitContainer = styled.View`
     max-width: 100%;
-    justify-content: flex-end;
-    align-self: center;
-    flex:1;
-    margin-bottom: 30px;
 `;
 
 export const ErrorMessage = styled.Text`
@@ -17,8 +13,4 @@ export const ErrorMessage = styled.Text`
     margin-left: 16px;
     font-weight: 500;
     font-size: 16px;
-`;
-
-export const CreditForm = styled.View`
-    flex: 1;
 `;


### PR DESCRIPTION
# Summary
This PR includes a fix to a crash that occurs when trying to switch a country in the `NewCreditForm` screen. 
The crash happens due to a crash with Stripe's `MainCardForm` and React Native's `KeyboardAvoidingView`.
Since that screen is fairly compact, `KeyboardAvoidingView` can be removed as the inputs shouldn't go under the Keyboard anyway.

|Before|After|
|---|---|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 18 50 07" src="https://github.com/user-attachments/assets/5847e8cc-b43b-4208-9fe2-df1b076671b7" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 18 48 44" src="https://github.com/user-attachments/assets/20fb4984-1e4e-4017-a948-18c19c339281" />|
