### PR TITLE
AF-519: Set minimal passenger number to 1 when value is invalid

### DIFF
--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -1147,14 +1147,15 @@ const RidePageContextProvider = ({ children }: {
       }
 
       // Workaround to fix the issue with the passengers state
-      const isNonPooling = chosenService.pooling === POOLING_TYPES.NO || chosenService.pooling === POOLING_TYPES.PASSIVE;
+      const validPassengers = Math.max(Number(numberOfPassengers) || 0, 1);
+      const isNonPooling = chosenService?.pooling === POOLING_TYPES.NO;
 
       const rideToCreate = {
         serviceId: chosenService?.id,
         estimationId: chosenService?.estimationId,
         paymentMethodId: ride.paymentMethodId,
         rideType: 'passenger',
-        numberOfPassengers: isNonPooling ? 1 : numberOfPassengers,
+        numberOfPassengers: isNonPooling ? 1 : validPassengers,
         ...(ride.scheduledTo && { scheduledTo: scheduledToMoment }),
         stopPoints: stopPoints.map((sp, i) => ({
           lat: Number(sp.lat),

--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -8,7 +8,6 @@ import { useNavigation } from '@react-navigation/native';
 import _, { pick } from 'lodash';
 import moment, { Moment } from 'moment-timezone';
 import debounce from 'lodash/debounce';
-import { POOLING_TYPES } from 'pages/ActiveRide/RideDrawer/RideOptions/RideButtons';
 import { PAYMENT_MODES } from '../../pages/Payments/consts';
 import offlinePaymentMethod from '../../pages/Payments/offlinePaymentMethod';
 import i18n from '../../I18n';
@@ -60,6 +59,7 @@ interface RideFeedback {
   type: string;
   source: string;
 }
+
 export interface RideInterface {
   priceCurrency?: any;
   priceAmount?: any;
@@ -84,6 +84,12 @@ export interface RideInterface {
   cancellationReasonId?: string;
   businessAccountId?: string;
 }
+
+export const POOLING_TYPES = {
+  NO: 'no',
+  ACTIVE: 'active',
+  PASSIVE: 'passive',
+};
 
 type AdditionalCharge = {
   amount: number,

--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -8,6 +8,7 @@ import { useNavigation } from '@react-navigation/native';
 import _, { pick } from 'lodash';
 import moment, { Moment } from 'moment-timezone';
 import debounce from 'lodash/debounce';
+import { POOLING_TYPES } from 'pages/ActiveRide/RideDrawer/RideOptions/RideButtons';
 import { PAYMENT_MODES } from '../../pages/Payments/consts';
 import offlinePaymentMethod from '../../pages/Payments/offlinePaymentMethod';
 import i18n from '../../I18n';
@@ -47,7 +48,6 @@ import { APP_ROUTES, MAIN_ROUTES } from '../../pages/routes';
 import * as navigationService from '../../services/navigation';
 import { BottomSheetContext } from '../bottomSheetContext';
 import { VirtualStationsContext } from '../virtualStationsContext';
-import { POOLING_TYPES } from 'pages/ActiveRide/RideDrawer/RideOptions/RideButtons';
 
 
 type Dispatch<A> = (value: A) => void;

--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -47,6 +47,7 @@ import { APP_ROUTES, MAIN_ROUTES } from '../../pages/routes';
 import * as navigationService from '../../services/navigation';
 import { BottomSheetContext } from '../bottomSheetContext';
 import { VirtualStationsContext } from '../virtualStationsContext';
+import { POOLING_TYPES } from 'pages/ActiveRide/RideDrawer/RideOptions/RideButtons';
 
 
 type Dispatch<A> = (value: A) => void;
@@ -1140,7 +1141,7 @@ const RidePageContextProvider = ({ children }: {
       }
 
       // Workaround to fix the issue with the passengers state
-      const isNonPooling = chosenService.pooling === 'no' || chosenService.pooling === 'passive';
+      const isNonPooling = chosenService.pooling === POOLING_TYPES.NO || chosenService.pooling === POOLING_TYPES.PASSIVE;
 
       const rideToCreate = {
         serviceId: chosenService?.id,

--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -1138,12 +1138,16 @@ const RidePageContextProvider = ({ children }: {
         const unixScheduledTo = moment.unix(Number(ride.scheduledTo) / 1000);
         scheduledToMoment = await getLocationTimezoneTime(pickupLocation.lat, pickupLocation.lng, unixScheduledTo);
       }
+
+      // Workaround to fix the issue with the passengers state
+      const isNonPooling = chosenService.pooling === 'no' || chosenService.pooling === 'passive';
+
       const rideToCreate = {
         serviceId: chosenService?.id,
         estimationId: chosenService?.estimationId,
         paymentMethodId: ride.paymentMethodId,
         rideType: 'passenger',
-        numberOfPassengers,
+        numberOfPassengers: isNonPooling ? 1 : numberOfPassengers,
         ...(ride.scheduledTo && { scheduledTo: scheduledToMoment }),
         stopPoints: stopPoints.map((sp, i) => ({
           lat: Number(sp.lat),

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
@@ -12,7 +12,7 @@ import {
   Container, RowContainer, ButtonContainer, ButtonText, StyledButton, HALF_WIDTH,
   PickerDate, PickerTimeRange, PickerTitle, ErrorText, ButtonContainerWithError, ButtonWithError,
 } from './styled';
-import {POOLING_TYPES, RidePageContext} from '../../../../../context/newRideContext';
+import { POOLING_TYPES, RidePageContext } from '../../../../../context/newRideContext';
 import NoteButton from '../../../../../Components/GenericRideButton';
 import i18n from '../../../../../I18n';
 import plus from '../../../../../assets/bottomSheet/plus.svg';

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
@@ -34,7 +34,7 @@ import ErrorPopup from '../../../../../popups/TwoButtonPopup';
 import { capitalizeFirstLetter, getPaymentMethod } from '../../../../../pages/Payments/cardDetailUtils';
 import { externalPaymentMethod } from '../../../../../pages/Payments/externalPaymentMethod';
 
-const POOLING_TYPES = {
+export const POOLING_TYPES = {
   NO: 'no',
   ACTIVE: 'active',
   PASSIVE: 'passive',

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
@@ -12,7 +12,7 @@ import {
   Container, RowContainer, ButtonContainer, ButtonText, StyledButton, HALF_WIDTH,
   PickerDate, PickerTimeRange, PickerTitle, ErrorText, ButtonContainerWithError, ButtonWithError,
 } from './styled';
-import { RidePageContext } from '../../../../../context/newRideContext';
+import {POOLING_TYPES, RidePageContext} from '../../../../../context/newRideContext';
 import NoteButton from '../../../../../Components/GenericRideButton';
 import i18n from '../../../../../I18n';
 import plus from '../../../../../assets/bottomSheet/plus.svg';
@@ -33,12 +33,6 @@ import PassengersCounter from './PassengersCounter';
 import ErrorPopup from '../../../../../popups/TwoButtonPopup';
 import { capitalizeFirstLetter, getPaymentMethod } from '../../../../../pages/Payments/cardDetailUtils';
 import { externalPaymentMethod } from '../../../../../pages/Payments/externalPaymentMethod';
-
-export const POOLING_TYPES = {
-  NO: 'no',
-  ACTIVE: 'active',
-  PASSIVE: 'passive',
-};
 
 const TIME_WINDOW_CHANGE_HIGHLIGHT_TIME_MS = 500;
 interface RideButtonsProps {


### PR DESCRIPTION
This is a workaround for the non-functioning numberOfPassengers state. The idea is that whenever we send a request to create a ride with a "no" pooling service or "passive" pooling mode, we set the number of passengers to 1.