### PR TITLE
fix(BsPages): use useSafeAreaInsets for dynamic bottom margin instead of hardcoded Android value

### DIFF
--- a/examples/client/Locomotion/src/Components/BsPages/index.tsx
+++ b/examples/client/Locomotion/src/Components/BsPages/index.tsx
@@ -2,12 +2,12 @@ import React, {
   useCallback, useContext, useEffect, useMemo, useState,
 } from 'react';
 import {
-  Linking, Platform, Text, View,
+  Linking, Text, View,
 } from 'react-native';
 import Config from 'react-native-config';
 import styled, { ThemeContext } from 'styled-components';
 import { useBottomSheet } from '@gorhom/bottom-sheet';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import moment from 'moment';
 import { CancellationReasonsContext } from '../../context/cancellation-reasons';
 import objDefault from '../../lib/objDefault';
@@ -135,13 +135,13 @@ const Header = styled(View)`
 
 type FooterInterface = {
   fullWidthButtons: boolean | undefined;
+  bottomInset: number;
 }
 const Footer = styled(View) <FooterInterface>`
   width: 100%;
   display: flex;
   flex-direction: ${({ fullWidthButtons }) => (fullWidthButtons ? 'column' : 'row')};
-  margin-bottom: ${Platform.OS === 'android'
-    ? '35px' : '10px'};
+  margin-bottom: ${({ bottomInset }) => bottomInset}px;
   justify-content: space-between;
   align-items: center;
 `;
@@ -173,6 +173,8 @@ const RIDE_STATES_TO_BS_PAGES = objDefault({
   [RIDE_STATES.MATCHING]: BS_PAGES.CONFIRMING_RIDE,
   defaultValue: BS_PAGES.ACTIVE_RIDE,
 });
+
+const MIN_FOOTER_BOTTOM_MARGIN = 10;
 
 const BsPage = ({
   onSecondaryButtonPress,
@@ -206,8 +208,10 @@ const BsPage = ({
   subtitleTestId: string
 }) => {
   const buttonWidth = fullWidthButtons ? '100%' : '48%';
+  const insets = useSafeAreaInsets();
+  const bottomInset = Math.max(insets.bottom, MIN_FOOTER_BOTTOM_MARGIN);
   return (
-    <Container edges={['bottom']}>
+    <Container>
       <MainContent>
         <>
           {TitleText && (
@@ -229,7 +233,7 @@ const BsPage = ({
           {children}
         </>
       </MainContent>
-      <Footer fullWidthButtons={fullWidthButtons}>
+      <Footer fullWidthButtons={fullWidthButtons} bottomInset={bottomInset}>
         {ButtonText && (
           <OtherButton
             testID="bottomSheetConfirm"


### PR DESCRIPTION
## AF-4395

## Problem

On Android devices using **on-screen navigation buttons** (e.g. Pixel 6 with Android 16), bottom sheet content was being cut off — the address text overlapped the Confirm button, and date rows in the scheduling flow were partially hidden beneath the navigation bar.

**Root cause:** The `Footer` styled component had a hardcoded `margin-bottom`:

```ts
// Before — hardcoded platform check
margin-bottom: ${Platform.OS === 'android' ? '35px' : '10px'};
```

On Android with on-screen navigation buttons, the navigation bar is **~48px** tall. The hardcoded `35px` was insufficient, clipping content underneath it. On gesture-based Android navigation the inset is ~0-20px, and on iOS ~34px, so the `35px` happened to be adequate on those — explaining why the bug was Android on-screen-buttons only.

The `Container` (`SafeAreaView` with `edges={['bottom']}`) was intended to handle bottom insets, but `SafeAreaView` does not reliably propagate bottom insets to content rendered inside `@gorhom/bottom-sheet` on Android, leaving the hardcoded margin as the only protection.

## Fix

Replace the hardcoded platform check with `useSafeAreaInsets()` from `react-native-safe-area-context`, which returns the **actual** system navigation bar height for the current device and navigation mode at runtime.

```ts
// After — real inset from the device
const insets = useSafeAreaInsets();
const bottomInset = Math.max(insets.bottom, MIN_FOOTER_BOTTOM_MARGIN); // min 10px for aesthetics
```

`Footer` now accepts a `bottomInset` prop and applies it dynamically:

```ts
margin-bottom: ${({ bottomInset }) => bottomInset}px;
```

`edges={['bottom']}` removed from `Container` since bottom inset is now handled explicitly via `Footer`.  
`Platform` removed from imports — it was only used for the old margin check.

## Files Changed

**`examples/client/Locomotion/src/Components/BsPages/index.tsx`**
- Removed `Platform` from `react-native` imports
- Added `useSafeAreaInsets` to `react-native-safe-area-context` import
- Added `MIN_FOOTER_BOTTOM_MARGIN = 10` constant
- Updated `FooterInterface` type: added `bottomInset: number`
- Changed `Footer` `margin-bottom` from hardcoded platform value to dynamic `${({ bottomInset }) => bottomInset}px`
- In `BsPage`: added `useSafeAreaInsets()` hook + `Math.max(insets.bottom, MIN_FOOTER_BOTTOM_MARGIN)` calculation
- Removed `edges={['bottom']}` from `Container`
- Passed `bottomInset={bottomInset}` to `Footer`

## Expected Behaviour After Fix
| Device / Nav mode | `insets.bottom` | `bottomInset` applied |
|---|---|---|
| Android on-screen buttons (Pixel 6) | ~48px | 48px ✅ |
| Android gesture navigation | ~0px | 10px (min) ✅ |
| iOS Face ID devices | ~34px | 34px ✅ |
| iOS home button devices | ~0px | 10px (min) ✅ |
