### PR TITLE
AF-7980 | fix(new-ride): incorporate payment method into service estimations

### DIFF
--- a/examples/client/Locomotion/src/context/newRideContext/api.js
+++ b/examples/client/Locomotion/src/context/newRideContext/api.js
@@ -1,8 +1,10 @@
 import network from '../../services/network';
 
-export const createServiceEstimations = async (stopPoints, scheduledTo, businessAccountId) => {
+export const createServiceEstimations = async (stopPoints, scheduledTo, businessAccountId, paymentMethodId) => {
   try {
-    const { data } = await network.post('api/v1/services/service-estimations', { stopPoints, scheduledTo, businessAccountId });
+    const { data } = await network.post('api/v1/services/service-estimations', {
+      stopPoints, scheduledTo, businessAccountId, paymentMethodId,
+    });
     return data;
   } catch (e) {
     console.error(e);

--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -241,6 +241,9 @@ export const RidePageContext = createContext<RidePageContextInterface>({
 
 const HISTORY_RECORDS_NUM = 10;
 
+const areStopPointsReady = (stopPoints: any[]) => stopPoints.length > 0
+  && stopPoints.every(sp => sp.lat && sp.lng && sp.description);
+
 const RidePageContextProvider = ({ children }: {
   children: any
 }) => {
@@ -445,7 +448,7 @@ const RidePageContextProvider = ({ children }: {
         scheduledTime = await getLocationTimezoneTime(formattedStopPoints[0].lat, formattedStopPoints[0].lng, unixScheduledTo);
       }
       const { estimations, services } = await rideApi
-        .createServiceEstimations(formattedStopPoints, scheduledTime, relevantBusinessAccountId);
+        .createServiceEstimations(formattedStopPoints, scheduledTime, relevantBusinessAccountId, ride.paymentMethodId);
 
       const tags = getEstimationTags(estimations);
       const formattedEstimations = formatEstimations(services, estimations, tags);
@@ -502,8 +505,7 @@ const RidePageContextProvider = ({ children }: {
 
   const validateRequestedStopPoints = (reqSps: any[], paymentChosen = true) => {
     const stopPoints = reqSps;
-    const isSpsReady = stopPoints.every(r => r.lat && r.lng && r.description);
-    if (stopPoints.length && isSpsReady) {
+    if (areStopPointsReady(stopPoints)) {
       tryServiceEstimations(paymentChosen);
     } else if (![BS_PAGES.ADDRESS_SELECTOR, BS_PAGES.LOADING].includes(currentBsPage)) {
       // reset req stop point request
@@ -675,6 +677,11 @@ const RidePageContextProvider = ({ children }: {
   useEffect(() => {
     validateRequestedStopPoints(requestStopPoints, false);
   }, [requestStopPoints]);
+
+  useEffect(() => {
+    if (!areStopPointsReady(requestStopPoints)) return;
+    tryServiceEstimations(true);
+  }, [ride.paymentMethodId]);
 
   const getRideFromApi = async (rideId: string): Promise<RideInterface> => formatRide(await rideApi.getRide(rideId));
 


### PR DESCRIPTION
Incorporate payment method into service pricing estimations when stoppoints are ready

CC Conterpart:
https://github.com/Autofleet/control-center/pull/3702

Part-of: AF-7980