### PR TITLE
feat(android): bump NDK r27.1 → r28 for 16 KB page-size compliance [AF-8872]

### DIFF
--- a/examples/client/Locomotion/android/build.gradle
+++ b/examples/client/Locomotion/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         targetSdkVersion = 35
         supportLibVersion = "35.0.0"
         kotlinVersion = "2.0.21"
-        ndkVersion = "27.1.12297006"
+        ndkVersion = "28.0.12433566"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary
- Bumps `ndkVersion` from `27.1.12297006` → `28.0.12433566` in `android/build.gradle`
- NDK r28 aligns ELF LOAD segments to 16 KB (`2**14`) by default for all CMake-built libs

## Baseline alignment audit (arm64-v8a + x86_64)
```
TOTAL: 46 ✓ / 0 ✗
zipalign: Verification successful
libjsc.so: absent (Hermes-only — expected)
libhermes.so / libhermestooling.so: ✓ 2**14 (16 KB)
```
All 23 native libs per ABI are 16 KB-aligned. No prebuilt `.so` remediation needed (L3 = no-op).

## Jira
AF-8872 (sub-task of AF-2875)

## Test plan
- [ ] Build `app:assembleDebug` passes (verified locally, 4m 54s)
- [ ] Alignment audit: 46 ✓ / 0 ✗ (verified locally)
- [ ] `libjsc.so` absent ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)