### PR TITLE
feat(android/ios): remove react-native-fast-image, migrate to stock Image [AF-8873]

### DIFF
--- a/examples/client/Locomotion/ios/Podfile.lock
+++ b/examples/client/Locomotion/ios/Podfile.lock
@@ -136,18 +136,6 @@ PODS:
   - hermes-engine (0.77.3):
     - hermes-engine/Pre-built (= 0.77.3)
   - hermes-engine/Pre-built (0.77.3)
-  - libwebp (1.5.0):
-    - libwebp/demux (= 1.5.0)
-    - libwebp/mux (= 1.5.0)
-    - libwebp/sharpyuv (= 1.5.0)
-    - libwebp/webp (= 1.5.0)
-  - libwebp/demux (1.5.0):
-    - libwebp/webp
-  - libwebp/mux (1.5.0):
-    - libwebp/demux
-  - libwebp/sharpyuv (1.5.0)
-  - libwebp/webp (1.5.0):
-    - libwebp/sharpyuv
   - lottie-ios (4.4.1)
   - lottie-react-native (6.7.2):
     - DoubleConversion
@@ -1949,10 +1937,6 @@ PODS:
     - React-Core
   - RNDeviceInfo (11.1.0):
     - React-Core
-  - RNFastImage (8.6.1):
-    - React-Core
-    - SDWebImage (~> 5.11.1)
-    - SDWebImageWebPCoder (~> 0.8.4)
   - RNFBApp (21.14.0):
     - Firebase/CoreOnly (= 11.11.0)
     - React-Core
@@ -2178,12 +2162,6 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - SDWebImage (5.11.1):
-    - SDWebImage/Core (= 5.11.1)
-  - SDWebImage/Core (5.11.1)
-  - SDWebImageWebPCoder (0.8.5):
-    - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.7.1)
   - Stripe (25.7.1):
     - StripeApplePay (= 25.7.1)
@@ -2392,7 +2370,6 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
-  - RNFastImage (from `../node_modules/react-native-fast-image`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBCrashlytics (from `../node_modules/@react-native-firebase/crashlytics`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -2418,15 +2395,12 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
-    - libwebp
     - lottie-ios
     - Mixpanel-swift
     - nanopb
     - OneSignalXCFramework
     - PromisesObjC
     - PromisesSwift
-    - SDWebImage
-    - SDWebImageWebPCoder
     - SocketRocket
     - Stripe
     - StripeApplePay
@@ -2616,8 +2590,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-picker/picker"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
-  RNFastImage:
-    :path: "../node_modules/react-native-fast-image"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBCrashlytics:
@@ -2659,7 +2631,6 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: b2187dbe13edb0db8fcb2a93a69c1987a30d98a4
-  libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: e047b1d2e6239b787cc5e9755b988869cf190494
   lottie-react-native: 310a4c13f899df17fd1a2d6288504bf66b8f453f
   Mixpanel-swift: e5dd85295923e6a875acf17ccbab8d2ecb10ea65
@@ -2746,7 +2717,6 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 36aec380620fbc4ce7b8a048071cdb12e13723f3
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNDeviceInfo: b899ce37a403a4dea52b7cb85e16e49c04a5b88e
-  RNFastImage: 3207b9eb17c2425d574ca40db35185db6e324f4e
   RNFBApp: b67ded6e4b0a6c0fee5e4f8e75e3a31567949a08
   RNFBCrashlytics: 7ca976f1d196ea153079ca8abc123bca50b72427
   RNGestureHandler: f0580b83fe9ce7732dec4a8add37bf3204f85e27
@@ -2754,8 +2724,6 @@ SPEC CHECKSUMS:
   RNReanimated: ef80cf675203a39bb5e5464234cb08a0f0040ac2
   RNScreens: 7feff8baab9ec69110bce0011d45cb7e2b38be28
   RNSVG: cb725f4400af94396beaeab55098e0a57f2ee020
-  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
-  SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: cba7aef14749955c8bbcbe71ecebd84088c6b364
   stripe-react-native: 93620ea57e941e696197d32985d42ca747205ffb

--- a/examples/client/Locomotion/package-lock.json
+++ b/examples/client/Locomotion/package-lock.json
@@ -56,7 +56,6 @@
         "react-native-date-picker": "^5.0.13",
         "react-native-device-info": "^11.1.0",
         "react-native-draglist": "3.9.5",
-        "react-native-fast-image": "^8.5.11",
         "react-native-geolocation-service": "^5.3.1",
         "react-native-gesture-handler": "2.30.0",
         "react-native-image-picker": "^4.8.2",
@@ -14969,16 +14968,6 @@
       "peerDependencies": {
         "react": ">=17.0.1",
         "react-native": ">=0.64.0"
-      }
-    },
-    "node_modules/react-native-fast-image": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/react-native-fast-image/-/react-native-fast-image-8.6.1.tgz",
-      "integrity": "sha512-ILuP7EuakqHNzTr8ZbumhuxG4tE/wGQ66z4nEEuzc0FlqY6rYaPsnq/UD2ahoyFj6QP1WvA2RIK3odib+VcqWg==",
-      "license": "(MIT AND Apache-2.0)",
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-fit-image": {

--- a/examples/client/Locomotion/package.json
+++ b/examples/client/Locomotion/package.json
@@ -66,7 +66,6 @@
     "react-native-date-picker": "^5.0.13",
     "react-native-device-info": "^11.1.0",
     "react-native-draglist": "3.9.5",
-    "react-native-fast-image": "^8.5.11",
     "react-native-geolocation-service": "^5.3.1",
     "react-native-gesture-handler": "2.30.0",
     "react-native-image-picker": "^4.8.2",

--- a/examples/client/Locomotion/src/Components/Thumbnail/index.js
+++ b/examples/client/Locomotion/src/Components/Thumbnail/index.js
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { Image, StyleSheet } from 'react-native';
-import FastImage from 'react-native-fast-image';
 import propsTypes from 'prop-types';
 import styled from 'styled-components';
 import Button from '../Button';
@@ -55,7 +54,7 @@ const myThumbnail = (props) => {
   defaultStyles.linearGradient.height = props.size;
   defaultStyles.linearGradient = Object.assign(defaultStyles.linearGradient);
   const styles = StyleSheet.create(defaultStyles);
-  const ImageComponent = props.source && props.source.substring(0, 4) === 'http' ? FastImage : Image;
+  const ImageComponent = Image;
   const borderRadius = { borderRadius: props.size };
   const borderRadiusSmall = { borderRadius: (props.size - 10) / 2 };
   return (


### PR DESCRIPTION
## Summary
- Replaces `FastImage` with React Native's stock `Image` in `Thumbnail/index.js` (the only usage site)
- Removes `react-native-fast-image` from `package.json` and node_modules
- Prunes 4 iOS pods: RNFastImage, SDWebImage, SDWebImageWebPCoder, libwebp

## Why
`react-native-fast-image` bundles `libwebp.so` as a prebuilt, which can be 4 KB-aligned.
Removing it eliminates a potential 16 KB page-size compliance blocker on Android.

The FastImage usage in `Thumbnail` only passed `source` and `style` — both fully supported by stock `Image` — with no use of priority, preload, or cache APIs. Behavior is identical.

## Migration
`src/Components/Thumbnail/index.js`
- Removed `import FastImage from 'react-native-fast-image'`  
- `const ImageComponent = ... ? FastImage : Image` → `const ImageComponent = Image`

## Jira
AF-8873 (sub-task of AF-2875)

## Test plan
- [ ] Thumbnail still renders (remote HTTP images + local fallback avatar both work)
- [ ] `node_modules/react-native-fast-image` absent
- [ ] iOS pod install removes RNFastImage / SDWebImage / SDWebImageWebPCoder / libwebp

🤖 Generated with [Claude Code](https://claude.com/claude-code)