### PR TITLE
fix(onboarding): email Continue stays disabled under fast input (Can Sign Up)

### DIFF
--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -41,7 +41,7 @@ import { BS_PAGES } from '../ridePageStateContext/utils';
 import {
   RIDE_STATES, RIDE_FINAL_STATES, STOP_POINT_TYPES, PAYMENT_STATES, CHARGE_FOR_TIP,
 } from '../../lib/commonTypes';
-import useBackgroundInterval from '../../lib/useBackgroundInterval';
+import useInterval from '../../lib/useInterval';
 import { formatSps } from '../../lib/ride/utils';
 import { APP_ROUTES, MAIN_ROUTES } from '../../pages/routes';
 import * as navigationService from '../../services/navigation';
@@ -656,7 +656,7 @@ const RidePageContextProvider = ({ children }: {
     }
   };
 
-  useBackgroundInterval(async () => {
+  useInterval(async () => {
     const appCurrentStateIsActive = AppState.currentState === 'active';
     setIsAppActive(appCurrentStateIsActive);
     if (appCurrentStateIsActive && user?.id && !rideRequestLoading) {

--- a/examples/client/Locomotion/src/context/newRideContext/index.tsx
+++ b/examples/client/Locomotion/src/context/newRideContext/index.tsx
@@ -41,7 +41,7 @@ import { BS_PAGES } from '../ridePageStateContext/utils';
 import {
   RIDE_STATES, RIDE_FINAL_STATES, STOP_POINT_TYPES, PAYMENT_STATES, CHARGE_FOR_TIP,
 } from '../../lib/commonTypes';
-import useInterval from '../../lib/useInterval';
+import useBackgroundInterval from '../../lib/useBackgroundInterval';
 import { formatSps } from '../../lib/ride/utils';
 import { APP_ROUTES, MAIN_ROUTES } from '../../pages/routes';
 import * as navigationService from '../../services/navigation';
@@ -656,7 +656,7 @@ const RidePageContextProvider = ({ children }: {
     }
   };
 
-  useInterval(async () => {
+  useBackgroundInterval(async () => {
     const appCurrentStateIsActive = AppState.currentState === 'active';
     setIsAppActive(appCurrentStateIsActive);
     if (appCurrentStateIsActive && user?.id && !rideRequestLoading) {

--- a/examples/client/Locomotion/src/pages/Profile/Email.js
+++ b/examples/client/Locomotion/src/pages/Profile/Email.js
@@ -59,17 +59,10 @@ const Email = () => {
     email: yup.string().required().email().matches(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/),
   });
 
-  const onChange = async (value) => {
+  const onChange = (value) => {
     setErrorText(false);
     setEmail(value);
-
-    try {
-      await emailSchema.validateAt('email', { email: value });
-    } catch (e) {
-      updateState({ email: '' });
-      return;
-    }
-    updateState({ email: value });
+    updateState({ email: emailSchema.isValidSync({ email: value }) ? value : '' });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Fix: onboarding email screen — Continue never enables → "Can Sign Up" stuck
`pages/Profile/Email.js` `onChange` was **async** (`await emailSchema.validateAt`). Continue is `isInvalid={!user.email}`. Under fast input (e2e types char-by-char via key events), the concurrent async validations **race**: a late-rejecting intermediate value (e.g. `…@fake.c`) runs `updateState({ email: '' })` *after* the valid full email set `user.email`, leaving it empty → Continue stays disabled → signup stuck on the email screen.

**Confirmed by BrowserStack video:** email is typed but Continue is greyed out; the flow never advances.

**Fix:** validate **synchronously** with `isValidSync`, so updates apply in keystroke order and the final valid value wins. (Verified `<uuid>@fake.com` → `isValidSync === true`.)

## Note
This branch previously also swapped the active-ride poll timer as an asap-ride attempt — **reverted**, because the asap failure turned out to be an e2e test bug (double-submit of the ride note), fixed in locomotion-e2e PR #73, not an app issue. This PR is now scoped to the email fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)