### PR TITLE
Fix date picker invisible on Android devices in dark mode

### DIFF
--- a/examples/client/Locomotion/src/Components/BsPages/index.tsx
+++ b/examples/client/Locomotion/src/Components/BsPages/index.tsx
@@ -362,7 +362,6 @@ export const ConfirmPickupTime = (props: any) => {
       </RoundedButton>
       <DatePickerPoppup
         testID="datePicker"
-        textColor="black"
         isVisible={isDatePickerOpen}
         date={tempSelectedDate}
         maximumDate={getFutureRideMaxDate(futureBookingDays)}

--- a/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
+++ b/examples/client/Locomotion/src/pages/ActiveRide/RideDrawer/RideOptions/RideButtons/index.tsx
@@ -184,7 +184,6 @@ const RideButtons = ({
         </ButtonContainer>
         <DatePickerPoppup
           testID="datePicker"
-          textColor="black"
           isVisible={isDatePickerOpen}
           date={tempSelectedDate}
           maximumDate={getFutureRideMaxDate(futureBookingDays)}

--- a/examples/client/Locomotion/src/popups/DatePickerPoppup/index.tsx
+++ b/examples/client/Locomotion/src/popups/DatePickerPoppup/index.tsx
@@ -26,6 +26,7 @@ export default ({
         {title}
         <DatePicker
           {...props}
+          theme="light"
           locale={getUserLanguageCode()}
           is24hourSource="locale"
           date={date}


### PR DESCRIPTION
## Problem

Since the RN 0.77 upgrade (#936), the "Set your pickup window" date picker appears blank on Android — the wheels take up space but nothing is visible.

## Root cause

#936 also bumped `react-native-date-picker` 4.2.6 → 5.0.13. [v5.0.0 removed the `textColor` prop](https://github.com/henninghall/react-native-date-picker/releases/tag/5.0.0) in favor of a `theme` prop that defaults to `"auto"` (follows the device's system theme). The app still passed `textColor="black"`, which is now silently ignored, so on Android devices with system **dark mode** enabled the picker renders white text on `DatePickerPoppup`'s hardcoded white background — invisible but still scrollable.

iOS is unaffected because the app forces light mode (`UIUserInterfaceStyle: Light` in Info.plist). This is also why the bug only reproduces on Android devices in dark mode.

## Fix

- Force `theme="light"` on the `DatePicker` in `DatePickerPoppup`, matching its hardcoded white background.
- Remove the dead `textColor="black"` props from both callers.

The Ride History range picker uses the library's `modal` mode, which supplies its own dark-mode-aware background, so it is unaffected and unchanged.

## Testing

To reproduce/verify: set an Android device to system dark mode and open the pickup-window picker. Broken on current release; wheels visible with this fix.